### PR TITLE
:construction_worker: Define reusable workflows for sub-projects

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -1,0 +1,66 @@
+name: Docker Publish Workflow
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME}}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ inputs.image }}
+          tags: |
+            # 1.2.3
+            type=semver,pattern={{version}}
+            # disabled if major zero
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+            # generate lates from default branch
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', github.event.repository.default_branch) }}
+
+      - name: Checkout sources
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: 'maven'
+
+      - name: Build with Maven
+        run: mvn --batch-mode --update-snapshots clean package
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/reusable-maven-test.yml
+++ b/.github/workflows/reusable-maven-test.yml
@@ -1,0 +1,21 @@
+name: Maven Tests
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          cache: 'maven'
+
+      - name: Run Tests with Maven
+        run: mvn --batch-mode --update-snapshots clean test

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -1,0 +1,32 @@
+name: Create Release
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    name: "Release"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Check-out"
+        uses: actions/checkout@v3
+      - name: "Generate release changelog"
+        id: generate-release-changelog
+        uses: heinrichreimer/github-changelog-generator-action@v2.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          onlyLastTag: "true" # set to false if no tags exist (buggy with only one tag)
+          stripHeaders: "true"
+          stripGeneratorNotice: "true"
+      - name: Extract the VERSION name
+        id: get-version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+      - name: "Create GitHub release"
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ github.ref }}
+          name: "${{ steps.get-version.outputs.VERSION }}"
+          body: "${{ steps.generate-release-changelog.outputs.changelog }}"
+          prerelease: ${{ startsWith(steps.get-version.outputs.VERSION, 'v0.') }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          draft: True


### PR DESCRIPTION
Define reusable workflows that can be called from sub-projects.

See https://docs.github.com/en/actions/using-workflows/reusing-workflows for documentation.