### PR TITLE
:green_heart: Do not require Docker secrets

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -8,9 +8,7 @@ on:
         type: string
     secrets:
       DOCKERHUB_USERNAME:
-        required: true
       DOCKERHUB_TOKEN:
-        required: true
 
 jobs:
   build:


### PR DESCRIPTION
Apparently secrets are taken from the forking repository in case of a PR, which means that the docker-publish workflow is called without secrets and fails.

However, secrets are not even  used in this case, so do not require them. A call from push to main without secrets will fail at the login action.