### PR TITLE
Update to Java 21

### DIFF
--- a/.github/workflows/reusable-docker-publish.yml
+++ b/.github/workflows/reusable-docker-publish.yml
@@ -38,10 +38,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
           cache: 'maven'
 

--- a/.github/workflows/reusable-maven-test.yml
+++ b/.github/workflows/reusable-maven-test.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'adopt'
           cache: 'maven'
 


### PR DESCRIPTION
This pull request includes changes to update the Java Development Kit (JDK) version used in the GitHub workflow configurations. The most important changes are:

Updates to JDK version:

* [`.github/workflows/reusable-docker-publish.yml`](diffhunk://#diff-a85b56425efae71b4943b61b12218c1d3132bf336bd0b560b8407b92ce411656L41-R44): Changed the JDK setup from version 17 to version 21.
* [`.github/workflows/reusable-maven-test.yml`](diffhunk://#diff-7537ad483d69ce28f400f49c4864b5acbd39dedbb75f27d68c7793533f12c17aL13-R16): Changed the JDK setup from version 17 to version 21.