### PR TITLE
Fix message generation in the release workflow

### DIFF
--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -9,7 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          # Needed for correct Maven version detection
+          fetch-depth: 0
       - name: "Generate release changelog"
         id: generate-release-changelog
         uses: heinrichreimer/github-changelog-generator-action@v2.3


### PR DESCRIPTION
This PR fixes the release message generator by making sure that the whole history is checked out and the previous tag can be found. This reflects a change in behavior for the checkout action.

* [`.github/workflows/reusable-release.yml`](diffhunk://#diff-2d68e0278e11def6c652ff37467f504b2445acd713e397688764a7ba9fab4e61L12-R16): Updated `actions/checkout` from version 3 to version 4, added `ref` and `fetch-depth` parameters to ensure correct Maven version detection.