### PR TITLE
Extend Copyright notice to 2025

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright 2022 Stefan Haun and contributors
+Copyright 2022-2025 Stefan Haun and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ Please check the sub-projects linked above to see where the contribution would f
 
 ## License
 
-[MIT](LICENSE.txt) © 2022 Stefan Haun and contributors
+[MIT](LICENSE.txt) © 2022-2025 Stefan Haun and contributors


### PR DESCRIPTION
This pull request updates copyright years across the project to reflect the current year. The changes ensure that the project documentation and licensing are up-to-date.

### Updates to copyright information:

- [`LICENSE.txt`](diffhunk://#diff-d0ed4cc3fb70489fe51c7e0ac180cba2a7472124f9f9e9ae67b01a37fbd580b7L1-R1): Updated the copyright years from "2022" to "2022-2025" to include the current year.
- [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L43-R43): Updated the copyright year in the license section from "2022" to "2022-2025" for consistency with the `LICENSE.txt` file.